### PR TITLE
[docs] Point to pattern in book and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-## Github Portal
-Lists all InnerSource projects of Philips in an interactive and easy to use way. Can be used as a template for implementing the [InnerSource portal pattern](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/innersource-portal.md) by the [InnerSource Commons community](http://innersourcecommons.org/).
+## GitHub Portal
+Lists all InnerSource projects of Philips in an interactive and easy to use way. Can be used as a template for implementing the [InnerSource Portal pattern](https://patterns.innersourcecommons.org/p/innersource-portal) by the [InnerSource Commons](http://innersourcecommons.org/) community.
 
 ## Inspiration
-This project is heavily inspired by the [SAP Innersource project portal.](https://github.com/SAP/project-portal-for-innersource)
+This project is heavily inspired by the [SAP Project Portal for InnerSource](https://github.com/SAP/project-portal-for-innersource).
 
 ## State
 Work in progress - Functional, but not ready for production.
 
 ## Technology Stack
-[Blazor Web Assembly](https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor)  
-.NET Core 3.1
-[TailwindCSS](https://tailwindcss.com/)
+* [Blazor Web Assembly](https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor)  
+* .NET Core 3.1
+* [TailwindCSS](https://tailwindcss.com/)
 
 ## Information
-More information(such as getting-started, demo page, etc) is coming soon.
+More information (such as getting-started, demo page, etc) is coming soon.


### PR DESCRIPTION
Hi @Brend-Smits.

I know that this is an early release and work in progress and all.
Still I figured you might already appreciate some contributions.

What I changed:
* Rather than pointing to the pattern in the GitHub repo, I changed the link to point to the pattern in our book. That link is likely to be more stable.
* Also made some other formatting and spelling fixes/suggestions.

Looking forward to your review :)